### PR TITLE
Switch to using the HTTPS endpoint

### DIFF
--- a/src/main/java/com/postmark/java/PostmarkClient.java
+++ b/src/main/java/com/postmark/java/PostmarkClient.java
@@ -165,7 +165,7 @@ public class PostmarkClient {
         try {
 
             // Create post request to Postmark API endpoint
-            HttpPost method = new HttpPost("http://api.postmarkapp.com/email");
+            HttpPost method = new HttpPost("https://api.postmarkapp.com/email");
 
             // Add standard headers required by Postmark
             method.addHeader("Accept", "application/json");


### PR DESCRIPTION
as recommended by [the API reference overview](http://developer.postmarkapp.com/developer-api-overview.html):

> We recommend using SSL encryption by issuing requests through HTTPS, however it’s not enforced.

since we're otherwise sending our API tokens in clear.
